### PR TITLE
Expand property `keyboardInfo` scope

### DIFF
--- a/KeyboardMan/KeyboardMan.swift
+++ b/KeyboardMan/KeyboardMan.swift
@@ -56,7 +56,7 @@ public class KeyboardMan: NSObject {
 
     public var appearPostIndex = 0
 
-    var keyboardInfo: KeyboardInfo? {
+    public private(set) var keyboardInfo: KeyboardInfo? {
         willSet {
             guard UIApplication.sharedApplication().applicationState != .Background else {
                 return


### PR DESCRIPTION
In some case, I want to use `keyboardInfo.animationDuration` or `keyboardInfo.animationCurve` to shrink my messageToolBar.

`public var postKeyboardInfo: ((keyboardMan: KeyboardMan, keyboardInfo: KeyboardInfo) -> Void)?`

 This property also can get the keyboardInfo, but sometime I need shrink my messageToolBar when keyboard is not appearing.
