### PR TITLE
Support for using KeyboardMan in app extension

### DIFF
--- a/KeyboardMan/KeyboardMan.swift
+++ b/KeyboardMan/KeyboardMan.swift
@@ -61,7 +61,7 @@ final public class KeyboardMan {
 
     public private(set) var keyboardInfo: KeyboardInfo? {
         willSet {
-            guard UIApplication.shared.applicationState != .background else {
+            guard UIApplication.sharedOrNil?.applicationState != .background else {
                 return
             }
 
@@ -158,7 +158,7 @@ final public class KeyboardMan {
 
     @objc private func keyboardWillShow(_ notification: Notification) {
 
-        guard UIApplication.shared.applicationState != .background else {
+        guard UIApplication.sharedOrNil?.applicationState != .background else {
             return
         }
 
@@ -167,7 +167,7 @@ final public class KeyboardMan {
     
     @objc private func keyboardWillChangeFrame(_ notification: Notification) {
 
-        guard UIApplication.shared.applicationState != .background else {
+        guard UIApplication.sharedOrNil?.applicationState != .background else {
             return
         }
 
@@ -178,7 +178,7 @@ final public class KeyboardMan {
 
     @objc private func keyboardWillHide(_ notification: Notification) {
 
-        guard UIApplication.shared.applicationState != .background else {
+        guard UIApplication.sharedOrNil?.applicationState != .background else {
             return
         }
 
@@ -187,7 +187,7 @@ final public class KeyboardMan {
 
     @objc private func keyboardDidHide(_ notification: Notification) {
 
-        guard UIApplication.shared.applicationState != .background else {
+        guard UIApplication.sharedOrNil?.applicationState != .background else {
             return
         }
 
@@ -195,3 +195,11 @@ final public class KeyboardMan {
     }
 }
 
+extension UIApplication {
+    // Return UIApplication.shared in an app target, `nil` in an app extension target.
+    static let sharedOrNil: UIApplication? = {
+        let selector = NSSelectorFromString("sharedApplication")
+        guard UIApplication.responds(to: selector) else { return nil }
+        return UIApplication.perform(selector).takeUnretainedValue() as? UIApplication
+    }()
+}

--- a/KeyboardMan/KeyboardMan.swift
+++ b/KeyboardMan/KeyboardMan.swift
@@ -200,6 +200,10 @@ extension UIApplication {
     static let sharedOrNil: UIApplication? = {
         let selector = NSSelectorFromString("sharedApplication")
         guard UIApplication.responds(to: selector) else { return nil }
-        return UIApplication.perform(selector).takeUnretainedValue() as? UIApplication
+        let application = UIApplication.perform(selector).takeUnretainedValue() as? UIApplication
+        
+        // The appDelegate is nil, normally it is in app extension context.  
+        guard let _ = application?.delegate else { return nil }
+        return application
     }()
 }

--- a/Messages.xcodeproj/project.pbxproj
+++ b/Messages.xcodeproj/project.pbxproj
@@ -410,6 +410,7 @@
 		50FA9A3A1B63AF69009BF2A0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
@@ -438,6 +439,7 @@
 		50FA9A3B1B63AF69009BF2A0 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
In app extension targets, the `UIApplication.shared` is not available.

This p-r supplies a workaround for it to use KeyboardMan in both app target and extension target.

Both MailMe app and Kingfisher is using this strategy so I think that it is proved to be AppStore-safe too.